### PR TITLE
Рефакторинг парсера пакетов

### DIFF
--- a/tpl.CPacketParser/error_table.def
+++ b/tpl.CPacketParser/error_table.def
@@ -1,0 +1,7 @@
+ENTRY(SUCCESS, "No error")
+ENTRY(BAD_INPUT, "Bad input")
+ENTRY(INVALID_FIELD, "Unknown field")
+ENTRY(NOT_SUCH_FILE, "Not such file")
+ENTRY(EMPTY_FILE, "Empty file")
+ENTRY(LARGE_FILE, "File is too large")
+ENTRY(ACCESS_DENIED, "Cannot open output file")


### PR DESCRIPTION
## Новая обработка ошибок на X-macro
Теперь при добавлении новой ошибки, добавлять нужно ТОЛЬКО в **error_table.def** в виде такой записи:

    ENTRY(<Код ошибки из перечисления>, <Описание ошибки в виде строки>)

А вызвать новое исключение теперь можно так:
 
    THROW_ERROR(<Код ошибки из перечисления>);

Или же с помощью прямого возврата:

    return VALID_CODE(<Код ошибки из перечисления>);

## Прототипы статических функций в заголовке

Подключаются только если определён макрос **__DLL**, нужны только для внутреннего использования самой библиотекой.

## Использование заголовка

Если пользователь подключает заголовок, для использования библиотеки, то ему __не__ нужно определять этот макрос до включения этого заголовка в программу. Хорошей практикой будет являться явное де-определение макроса перед включением:

``` C
#undef __DLL
#include "packet_parser.h"
```

Так пользователю доступны только 2 функции:

- ``` extern Parse_Result parse_packet(const char *packet_path, const char *output_path); ```
    Производит парсинг .tpl в .json. Возвращает значение ошибки.
  - _packet_path_ - путь к исходному .tpl пакету
  - _output_path_ - путь к выходному .json файлу

- ``` extern const char *parse_result_to_cstr(Parse_Result const val); ```
    Возвращает значение ошибки полученной от _parse_packet()_ в виде строки.
  - _val_ - значение ошибки, которое вернула функция _parse_packet()_

Перечисление _Parse_Result_ объявлено в заголовке.

## Пример использования

**parser_test.c:**
``` C
#undef __DLL
#include "packet_parser.h"
#include <stdlib.h>
#include <stdio.h>

int main(void){
    const char *input_path = "./packet.tpl";
    const char *output_path = "./out.json";
    
    Parse_Result oc;
    if ( oc = parse_packet(input_path, output_path) != PARSE_RESULT_SUCCESS ){
        fprintf(stderr, "Error while parsing %s:%s\nAborted.\n", input_path, parse_result_to_cstr(oc));
        abort();
    }

    printf("Parsed to %s successfully!\n", output_path);
    return 0;
}
```

``` Bash
> make
gcc -Ofast -std=c11 -ggdb -Wall -Wno-format -Wno-parentheses -shared packet_parser.c -o packet_parser.dll 
> gcc parser_test.c packet_parser.dll -o parser_test.exe 
> ./parser_test.exe
Parsed to ./out.json successfully!
```
